### PR TITLE
feat: migrate from hash router to History API for SEO-friendly URLs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ npm run build    # Production build → dist/
 npm run preview  # Preview production build locally
 ```
 
-No tests, linter, or CI pipeline configured.
+Requires Node.js >= 24. No tests, linter, or CI pipeline configured.
 
 ## Architecture
 
@@ -18,16 +18,20 @@ Vanilla JavaScript SPA (no framework) built with Vite. Zero runtime dependencies
 
 ### MVC-like Pattern
 
-- **`js/main.js`** — Entry point. Registers Service Worker (prod only via `import.meta.env.PROD`), initializes dark mode, sets up hash-based router.
-- **`js/router.js`** — Hash router (`#/home`, `#/about`, `#/tutorials`, `#/articles`, `#/hobbies`). Imports all controllers, switches content in `#root` based on `window.location.hash`.
-- **`controllers/`** — Each feature folder (home/, aboutMe/, tutorials/, articles/, hobbies/) has an index.js that exports a function creating a DOM element from its corresponding view template. Some controllers add runtime behavior (e.g., `articles/articles.js` swaps images by screen size).
+- **`js/main.js`** — Entry point. Registers Service Worker (prod only via `import.meta.env.PROD`), initializes dark mode, sets up History API router with client-side navigation (intercepts `<a>` clicks, uses `pushState`/`popstate`). Includes backward-compat redirect from old `#/` hash URLs.
+- **`js/router.js`** — History API router using `window.location.pathname`. Routes: `/`, `/home`, `/about`, `/tutorials`, `/articles`, `/hobbies`, plus article sub-pages (`/remove-password`, `/modern-combat`, `/intro-hybrids`). Switches content in `#root` by calling controller functions.
+- **`controllers/`** — Each feature folder (home/, aboutMe/, tutorials/, articles/, hobbies/) has an `index.js` that exports a function creating a DOM element from its corresponding view template. Some controllers add runtime behavior (e.g., `articles/articles.js` swaps images by screen size). `controllers/index.js` is the barrel file re-exporting all controllers.
 - **`views/`** — Mirrors controllers structure. Each file exports an HTML template literal string. These are set as `innerHTML` on elements created by controllers.
+
+### Routing & Navigation
+
+Internal links must use same-origin `<a>` tags without `target` attribute — `main.js` intercepts clicks and calls `history.pushState()`. External links (different hostname or with `target` attribute) are not intercepted. When adding new routes: add the case to `router.js`, create a controller + view, and update navigation links.
 
 ### Static Assets & PWA
 
-- **`public/`** — Files served as-is by Vite (no processing): `service-worker.js`, `manifest.json`, `assets/icons/`, `assets/images/`.
+- **`public/`** — Files served as-is by Vite (no processing): `service-worker.js`, `manifest.json`, `sitemap.xml`, `assets/icons/`, `assets/images/`.
 - All asset references use absolute paths (`/assets/...`) so Vite serves them from `public/` without hashing.
-- Service Worker (`public/service-worker.js`) uses cache-first strategy. Bump `CACHE_NAME` version when updating cached resources.
+- Service Worker (`public/service-worker.js`) uses cache-first strategy with navigation requests always returning `/index.html` (SPA fallback). Bump `CACHE_NAME` version when updating cached resources.
 
 ### CSS
 
@@ -42,4 +46,4 @@ Vanilla JavaScript SPA (no framework) built with Vite. Zero runtime dependencies
 
 ## Deployment
 
-Deployed on Vercel. Framework preset: **Vite**. Build output: `dist/`. Vercel auto-detects configuration from `package.json`.
+Deployed on Vercel. Framework preset: **Vite**. Build output: `dist/`. `vercel.json` has a catch-all rewrite (`/(.*) → /index.html`) for SPA client-side routing support.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Blog personal construido con HTML, CSS y JavaScript vanilla. Sin frameworks, sin
 
 ## Tecnologías
 
-- **JavaScript ES6+** — SPA con router hash-based y arquitectura MVC
+- **JavaScript ES6+** — SPA con History API router y arquitectura MVC
 - **CSS3** — Custom properties, BEM, responsive design, dark mode
 - **Vite** — Dev server con HMR y build de producción
 - **PWA** — Service Worker con cache-first strategy y manifest para instalación

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
     <section class="grid-container header-container">
       <section class="profile">
         <div class="profile__img-content">
-          <a class="profile__link" href="#/">
+          <a class="profile__link" href="/">
             <img class="profile__img" src="/assets/images/profile-photo.png" alt="Foto de perfil" />
           </a>
         </div>
@@ -90,19 +90,19 @@
       <nav class="main-nav">
         <ul class="main-nav__list">
           <li class="main-nav__item">
-            <a id="nav-home" class="main-nav__link" href="#/home">Inicio</a>
+            <a id="nav-home" class="main-nav__link" href="/home">Inicio</a>
           </li>
           <li class="main-nav__item">
-            <a id="nav-aboutme" class="main-nav__link" href="#/about">Sobre mí</a>
+            <a id="nav-aboutme" class="main-nav__link" href="/about">Sobre mí</a>
           </li>
           <li class="main-nav__item">
-            <a id="nav-tutorials" class="main-nav__link" href="#/tutorials">Tutoriales</a>
+            <a id="nav-tutorials" class="main-nav__link" href="/tutorials">Tutoriales</a>
           </li>
           <li class="main-nav__item">
-            <a id="nav-articles" class="main-nav__link" href="#/articles">Artículos</a>
+            <a id="nav-articles" class="main-nav__link" href="/articles">Artículos</a>
           </li>
           <li class="main-nav__item">
-            <a id="nav-hobbies" class="main-nav__link" href="#/hobbies">Pasatiempos</a>
+            <a id="nav-hobbies" class="main-nav__link" href="/hobbies">Pasatiempos</a>
           </li>
         </ul>
       </nav>

--- a/js/main.js
+++ b/js/main.js
@@ -44,9 +44,28 @@ darkMode.addEventListener("change", (event) => {
   if (!isDarkMode()) event.matches ? activateDarkMode() : activateLightMode();
 });
 
-router(window.location.hash);
-window.addEventListener("hashchange", () => {
-  router(window.location.hash);
+// Redirect old hash URLs to clean paths
+if (window.location.hash.startsWith("#/")) {
+  const path = window.location.hash.slice(1);
+  history.replaceState(null, "", path);
+}
+
+router(window.location.pathname);
+
+window.addEventListener("popstate", () => {
+  router(window.location.pathname);
+});
+
+document.addEventListener("click", (e) => {
+  const link = e.target.closest("a");
+  if (!link) return;
+  if (link.hostname !== window.location.hostname) return;
+  if (link.hasAttribute("target")) return;
+
+  const path = link.pathname;
+  e.preventDefault();
+  history.pushState(null, "", path);
+  router(path);
 });
 
 checkbox.addEventListener("change", () => {

--- a/js/router.js
+++ b/js/router.js
@@ -27,40 +27,38 @@ const router = (route = '') => {
   switch (route) {
     case '':
     case '/':
-    case '#/':
-    case '#/home':
-    case '/index.html':
+    case '/home':
       removeActive();
       navHome.classList.add('main-nav__link--active');
       return content.appendChild(Home.home());
 
-    case '#/about':
+    case '/about':
       removeActive();
       navAboutMe.classList.add('main-nav__link--active');
       return content.appendChild(AboutMe.aboutMe());
 
-    case '#/tutorials':
+    case '/tutorials':
       removeActive();
       navTutorials.classList.add('main-nav__link--active');
       return content.appendChild(Tutorials.tutorials());
 
-    case '#/articles':
+    case '/articles':
       removeActive();
       navArticles.classList.add('main-nav__link--active');
       return content.appendChild(Articles.articles());
 
-    case '#/hobbies':
+    case '/hobbies':
       removeActive();
       navHobbies.classList.add('main-nav__link--active');
       return content.appendChild(Hobbies.hobbies());
 
-    case '#/remove-password':
+    case '/remove-password':
       return content.appendChild(Home.removePass());
 
-    case '#/modern-combat':
+    case '/modern-combat':
       return content.appendChild(Home.modernCombat());
 
-    case '#/intro-hybrids':
+    case '/intro-hybrids':
       return content.appendChild(Home.introHybrids());
 
     default:

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "shell-v1.1.1";
+const CACHE_NAME = "shell-v1.2.0";
 const filesToCache = [
   "/",
   "/index.html",
@@ -45,6 +45,16 @@ self.addEventListener("activate", (event) => {
 });
 
 self.addEventListener("fetch", (event) => {
+  if (event.request.mode === "navigate") {
+    event.respondWith(
+      caches
+        .match("/index.html")
+        .then((response) => response || fetch(event.request))
+        .catch((err) => console.log("fetch: ", err))
+    );
+    return;
+  }
+
   event.respondWith(
     caches
       .match(event.request, { ignoreSearch: true })

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,7 +2,27 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://corteshvictor.dev/</loc>
-    <lastmod>2026-03-05</lastmod>
+    <lastmod>2026-03-06</lastmod>
     <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://corteshvictor.dev/about</loc>
+    <lastmod>2026-03-06</lastmod>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://corteshvictor.dev/tutorials</loc>
+    <lastmod>2026-03-06</lastmod>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://corteshvictor.dev/articles</loc>
+    <lastmod>2026-03-06</lastmod>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://corteshvictor.dev/hobbies</loc>
+    <lastmod>2026-03-06</lastmod>
+    <priority>0.6</priority>
   </url>
 </urlset>

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}

--- a/views/home/home.js
+++ b/views/home/home.js
@@ -6,7 +6,7 @@ const contentHome = `
 <article class="global-article">
     <a
         class="global-article__link" 
-        href="#/intro-hybrids"
+        href="/intro-hybrids"
     >
         <img 
             class="global-article__img" 
@@ -24,7 +24,7 @@ const contentHome = `
 <article class="global-article">
     <a
         class="global-article__link" 
-        href="#/remove-password"
+        href="/remove-password"
     >
         <img 
             class="global-article__img"
@@ -42,7 +42,7 @@ const contentHome = `
 <article class="global-article">
     <a
         class="global-article__link" 
-        href="#/modern-combat"
+        href="/modern-combat"
     >
         <img 
             class="global-article__img"


### PR DESCRIPTION
### What's this pull request do?

Migra el router de hash-based (`#/home`, `#/about`) a History API (`/home`, `/about`) para que Google pueda indexar cada ruta de forma independiente.

- Reemplaza `hashchange` por `pushState`/`popstate` con interceptor de clicks en `<a>` internos
- Agrega `vercel.json` con rewrite catch-all (`/(.*) → /index.html`) para acceso directo a URLs
- Actualiza el Service Worker con fallback de navegación a `/index.html`
- Agrega redirect de compatibilidad para URLs antiguas con `#/`
- Actualiza `sitemap.xml` con todas las rutas del sitio
- Actualiza `CLAUDE.md` y `README.md` para reflejar la nueva arquitectura

### Where should the reviewer start?

`js/main.js` — contiene el nuevo sistema de navegación con History API, el interceptor de clicks y el redirect de hash URLs antiguas.

### Comments additional and Screenshots (optional)

Las URLs internas ahora son limpias (`/tutorials` en vez de `/#/tutorials`), mejorando SEO y compatibilidad con crawlers.